### PR TITLE
Deployment: Dockerfile and Smithery config

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Use an official Node.js image as a parent image
+FROM node:18-alpine AS builder
+
+# Set the working directory in the container to /app
+WORKDIR /app
+
+# Copy package.json and package-lock.json into the container at /app
+COPY package.json package-lock.json ./
+
+# Install project dependencies
+RUN npm install
+
+# Copy the rest of the project's files into the container at /app
+COPY . .
+
+# Build the TypeScript project
+RUN npm run build
+
+# Production image
+FROM node:18-alpine
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy the build output and node_modules from the builder stage to the production image
+COPY --from=builder /app/build /app/build
+COPY --from=builder /app/node_modules /app/node_modules
+
+# Set environment variables
+ENV STABILITY_AI_API_KEY=your_api_key_here
+ENV IMAGE_STORAGE_DIRECTORY=/tmp/stability-ai-images
+
+# Create the image storage directory
+RUN mkdir -p /tmp/stability-ai-images
+
+# Expose port (if the application listens on a port)
+# EXPOSE 3000
+
+# Run the application
+ENTRYPOINT ["node", "build/index.js"]

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,21 @@
+# Smithery configuration file: https://smithery.ai/docs/deployments
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - stabilityAiApiKey
+    properties:
+      stabilityAiApiKey:
+        type: string
+        description: Your Stability AI API key.
+      imageStorageDirectory:
+        type: string
+        default: /tmp/stability-ai-images
+        description: Directory where generated images will be saved.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    config => ({ command: 'node', args: ['build/index.js'], env: { STABILITY_AI_API_KEY: config.stabilityAiApiKey, IMAGE_STORAGE_DIRECTORY: config.imageStorageDirectory || '/tmp/stability-ai-images' } })


### PR DESCRIPTION
This pull request introduces the following updates:

- **Dockerfile**: Introduces a Dockerfile to package the MCP for deployment across various environments.
- **Smithery Configuration**: Adds a Smithery YAML configuration file, which specifies how to start the MCP and what configuration options it supports. This enables hosting the MCP server on [Smithery](https://smithery.ai) and allows users to connect to the hosted version over SSE without additional dependencies. You may deploy your server by visiting your [server page](https://smithery.ai/server/mcp-server-stability-ai) and claiming it.

Please review these updates to verify their accuracy for your server. Let us know if you have any questions. 🙂