### PR TITLE
Add SSE support

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,13 @@ And then, if the output still isn't good enough, you can upscale it again:
 
 ## Cheatsheet
 
-| Environment Variable      | Description                                                                                               | Required | Default Value                                                                           | Example                                      |
-| ------------------------- | --------------------------------------------------------------------------------------------------------- | -------- | --------------------------------------------------------------------------------------- | -------------------------------------------- |
-| `STABILITY_AI_API_KEY`    | Your Stability AI API key. Get one at [platform.stability.ai](https://platform.stability.ai/account/keys) | Y        | N/A                                                                                     | `sk-1234567890`                              |
-| `IMAGE_STORAGE_DIRECTORY` | Directory where generated images will be saved                                                            | N        | `/tmp/tadasant-mcp-server-stability-ai` OR `C:\\Windows\\Temp\\mcp-server-stability-ai` | `/Users/admin/Downloads/stability-ai-images` |
+| Environment Variable      | Description                                                                                               | Required           | Default Value                                                                           | Example                                                                 |
+| ------------------------- | --------------------------------------------------------------------------------------------------------- | ------------------ | --------------------------------------------------------------------------------------- | ----------------------------------------------------------------------- |
+| `STABILITY_AI_API_KEY`    | Your Stability AI API key. Get one at [platform.stability.ai](https://platform.stability.ai/account/keys) | Y                  | N/A                                                                                     | `sk-1234567890`                                                         |
+| `IMAGE_STORAGE_DIRECTORY` | Directory where generated images will be saved                                                            | N                  | `/tmp/tadasant-mcp-server-stability-ai` OR `C:\\Windows\\Temp\\mcp-server-stability-ai` | `/Users/admin/Downloads/stability-ai-images`                            |
+| `GCS_PROJECT_ID`          | Google Cloud Project ID for storing images                                                                | N (Y if using SSE) | N/A                                                                                     | `your-project-id`                                                       |
+| `GCS_CLIENT_EMAIL`        | Google Cloud Service Account client email for storing images                                              | N (Y if using SSE) | N/A                                                                                     | `your-service-account@project.iam.gserviceaccount.com`                  |
+| `GCS_PRIVATE_KEY`         | Google Cloud Service Account private key for storing images                                               | N (Y if using SSE) | N/A                                                                                     | `-----BEGIN PRIVATE KEY-----\nYourKeyHere\n-----END PRIVATE KEY-----\n` |
 
 ## Claude Desktop
 

--- a/README.md
+++ b/README.md
@@ -144,6 +144,7 @@ And then, if the output still isn't good enough, you can upscale it again:
 | `GCS_PROJECT_ID`          | Google Cloud Project ID for storing images                                                                | N (Y if using SSE) | N/A                                                                                     | `your-project-id`                                                       |
 | `GCS_CLIENT_EMAIL`        | Google Cloud Service Account client email for storing images                                              | N (Y if using SSE) | N/A                                                                                     | `your-service-account@project.iam.gserviceaccount.com`                  |
 | `GCS_PRIVATE_KEY`         | Google Cloud Service Account private key for storing images                                               | N (Y if using SSE) | N/A                                                                                     | `-----BEGIN PRIVATE KEY-----\nYourKeyHere\n-----END PRIVATE KEY-----\n` |
+| `GCS_BUCKET_NAME`         | Google Cloud Storage bucket name for storing images                                                       | N (Y if using SSE) | N/A                                                                                     | `your-bucket-name`                                                      |
 
 ## Claude Desktop
 
@@ -174,6 +175,7 @@ Modify your `claude_desktop_config.json` file to add the following:
     "stability-ai": {
       "command": "npx",
       "args": [
+        "-y",
         "mcp-server-stability-ai"
       ],
       "env": {
@@ -193,6 +195,7 @@ On Windows, this might look more like:
     "stability-ai": {
       "command": "npx",
       "args": [
+        "-y",
         "mcp-server-stability-ai"
       ],
       "env": {
@@ -217,6 +220,20 @@ To install for Claude Desktop automatically via [Smithery](https://smithery.ai/s
 ```bash
 npx @smithery/cli install mcp-server-stability-ai --client claude
 ```
+
+## SSE Mode
+
+This server has the option to run in SSE mode by starting it with the following command:
+
+```bash
+npx mcp-server-stability-ai -y --sse
+```
+
+This mode is useful if you intend to deploy this server for third party usage over HTTP.
+
+You will need to set the `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_BUCKET_NAME`, and `GCS_PRIVATE_KEY` environment variables, because the server will store image files in Google Cloud Storage instead of its local filesystem.
+
+Note that the scheme for multitenancy is very naive and insecure: it uses the requestor's IP address to segment the GCS prefixes used to the store the images, and makes all images publicly accessible in order to communicate them back to the MCP client. So in theory, if someone knows your IP address and then name(s) of files you generated, they could access your images by guessing the URL.
 
 ## Roadmap
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,17 +1,18 @@
 {
   "name": "mcp-server-stability-ai",
-  "version": "0.0.1",
+  "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-server-stability-ai",
-      "version": "0.0.1",
+      "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7",
+        "express": "^4.21.2",
         "open": "^10.1.0",
         "zod": "^3.24.1"
       },
@@ -20,6 +21,7 @@
       },
       "devDependencies": {
         "@types/dotenv": "^6.1.1",
+        "@types/express": "^5.0.0",
         "@types/node": "^22.10.2",
         "typescript": "^5.7.2"
       }
@@ -35,6 +37,27 @@
         "zod": "^3.23.8"
       }
     },
+    "node_modules/@types/body-parser": {
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.19.5.tgz",
+      "integrity": "sha512-fB3Zu92ucau0iQ0JMCFQE7b/dv8Ot07NI3KaZIkIUNXq82k4eBAqUaneXfleGY9JWskeS9y+u0nXMyspcuQrCg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/connect": "*",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/connect": {
+      "version": "3.4.38",
+      "resolved": "https://registry.npmjs.org/@types/connect/-/connect-3.4.38.tgz",
+      "integrity": "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/dotenv": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/@types/dotenv/-/dotenv-6.1.1.tgz",
@@ -45,6 +68,46 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/express": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/@types/express/-/express-5.0.0.tgz",
+      "integrity": "sha512-DvZriSMehGHL1ZNLzi6MidnsDhUZM/x2pRdDIKdwbUNqqwHxMlRdkxtn6/EPKyqKpHqTl/4nRZsRNLpZxZRpPQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/body-parser": "*",
+        "@types/express-serve-static-core": "^5.0.0",
+        "@types/qs": "*",
+        "@types/serve-static": "*"
+      }
+    },
+    "node_modules/@types/express-serve-static-core": {
+      "version": "5.0.5",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-5.0.5.tgz",
+      "integrity": "sha512-GLZPrd9ckqEBFMcVM/qRFAP0Hg3qiVEojgEFsx/N/zKXsBzbGF6z5FBDpZ0+Xhp1xr+qRZYjfGr1cWHB9oFHSA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*",
+        "@types/qs": "*",
+        "@types/range-parser": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/@types/http-errors": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@types/http-errors/-/http-errors-2.0.4.tgz",
+      "integrity": "sha512-D0CFMMtydbJAegzOyHjtiKPLlvnm3iTZyZRSZoLq2mRhDdmLfIWOCYPfQJ4cu2erKghU++QvjcUjp/5h7hESpA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/mime": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/@types/mime/-/mime-1.3.5.tgz",
+      "integrity": "sha512-/pyBZWSLD2n0dcHE3hq8s8ZvcETHtEuF+3E7XVt0Ig2nvsVQXdghHVcEkIWjy9A0wKfTn97a/PSDYohKIlnP/w==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "22.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
@@ -54,6 +117,62 @@
       "dependencies": {
         "undici-types": "~6.20.0"
       }
+    },
+    "node_modules/@types/qs": {
+      "version": "6.9.18",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.18.tgz",
+      "integrity": "sha512-kK7dgTYDyGqS+e2Q4aK9X3D7q234CIZ1Bv0q/7Z5IwRDoADNU81xXJK/YVyLbLTZCoIwUoDoffFeF+p/eIklAA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/range-parser": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.7.tgz",
+      "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@types/send": {
+      "version": "0.17.4",
+      "resolved": "https://registry.npmjs.org/@types/send/-/send-0.17.4.tgz",
+      "integrity": "sha512-x2EM6TJOybec7c52BX0ZspPodMsQUd5L6PRwOunVyVUhXiBSKf3AezDL8Dgvgt5o0UfKNfuA0eMLr2wLT4AiBA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/mime": "^1",
+        "@types/node": "*"
+      }
+    },
+    "node_modules/@types/serve-static": {
+      "version": "1.15.7",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.15.7.tgz",
+      "integrity": "sha512-W8Ym+h8nhuRwaKPaDw34QUkwsGi6Rc4yYqvKFo5rm2FUEhCFbzVWrxXUxuKK8TASjWsysJY0nsmNCGhCOIsrOw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/http-errors": "*",
+        "@types/node": "*",
+        "@types/send": "*"
+      }
+    },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/array-flatten": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
+      "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
+      "license": "MIT"
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -70,6 +189,57 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/body-parser": {
+      "version": "1.20.3",
+      "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.20.3.tgz",
+      "integrity": "sha512-7rAxByjUMqQ3/bHJy7D6OGXvx/MMc4IqBn/X0fcM1QUcAItpZrBEYhWGem+tzXH90c+G01ypMcYJBO9Y30203g==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "content-type": "~1.0.5",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "on-finished": "2.4.1",
+        "qs": "6.13.0",
+        "raw-body": "2.5.2",
+        "type-is": "~1.6.18",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
+    "node_modules/body-parser/node_modules/iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/body-parser/node_modules/raw-body": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.5.2.tgz",
+      "integrity": "sha512-8zGqypfENjCIqGhgXToC8aB2r7YrBX+AQAfIPs/Mlk+BtPTztOvTS01NRW/3Eh60J+a48lt8qsCzirQ6loCVfA==",
+      "license": "MIT",
+      "dependencies": {
+        "bytes": "3.1.2",
+        "http-errors": "2.0.0",
+        "iconv-lite": "0.4.24",
+        "unpipe": "1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/bundle-name": {
@@ -96,6 +266,35 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.1.tgz",
+      "integrity": "sha512-BhYE+WDaywFg2TBWYNXAE+8B1ATnThNBqXHP5nQu0jWJdVvY2hvkpyB3qOmtmDePiS5/BDQ8wASEWGMWRG148g==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/call-bound": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/call-bound/-/call-bound-1.0.3.tgz",
+      "integrity": "sha512-YTd+6wGlNlPxSuri7Y6X8tY2dmm12UMH66RpKMhiX6rsk5wXXnYgbUcOt8kiS31/AjfoTOvCsE+w8nZQLQnzHA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "get-intrinsic": "^1.2.6"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/combined-stream": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
@@ -108,6 +307,18 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/content-disposition": {
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-0.5.4.tgz",
+      "integrity": "sha512-FveZTNuGw04cxlAiWbzi6zTAL/lhehaWbTtgluJh4/E95DqMwTmha3KZN1aAWA8cFIhHzMZUvLevkw5Rqk+tSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/content-type": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.5.tgz",
@@ -115,6 +326,30 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.1.tgz",
+      "integrity": "sha512-6DnInpx7SJ2AK3+CTUE/ZM0vWTUboZCegxhC2xiIydHR9jNuTAASBrfEpHhiGOZw/nX51bHt6YQl8jsGo4y/0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cookie-signature": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/cookie-signature/-/cookie-signature-1.0.6.tgz",
+      "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
+      "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "2.0.0"
       }
     },
     "node_modules/default-browser": {
@@ -175,6 +410,16 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/destroy": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/destroy/-/destroy-1.2.0.tgz",
+      "integrity": "sha512-2sJGJTaXIIaR1w4iJSNoN0hnMY7Gpc/n8D4qSCJw8QqFWXf7cuAgnEHxBpweaVcPevC2l3KpjYCx3NypQQgaJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8",
+        "npm": "1.2.8000 || >= 1.4.16"
+      }
+    },
     "node_modules/dotenv": {
       "version": "16.4.7",
       "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.4.7.tgz",
@@ -185,6 +430,144 @@
       },
       "funding": {
         "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/ee-first": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
+      "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==",
+      "license": "MIT"
+    },
+    "node_modules/encodeurl": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-2.0.0.tgz",
+      "integrity": "sha512-Q0n9HRi4m6JuGIV1eFlmvJB7ZEVxu93IrMyiMsGC0lrMJMWzRgx6WGquyfQgZVb31vhGgXnfmPNNXmxnOkRBrg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
+      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/escape-html": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
+      "integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
+      "license": "MIT"
+    },
+    "node_modules/etag": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/etag/-/etag-1.8.1.tgz",
+      "integrity": "sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/express": {
+      "version": "4.21.2",
+      "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
+      "integrity": "sha512-28HqgMZAmih1Czt9ny7qr6ek2qddF4FclbMzwhCREB6OFfH+rXAnuNCwo1/wFvrtbgsQDb4kSbX9de9lFbrXnA==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.8",
+        "array-flatten": "1.1.1",
+        "body-parser": "1.20.3",
+        "content-disposition": "0.5.4",
+        "content-type": "~1.0.4",
+        "cookie": "0.7.1",
+        "cookie-signature": "1.0.6",
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "finalhandler": "1.3.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "merge-descriptors": "1.0.3",
+        "methods": "~1.1.2",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "path-to-regexp": "0.1.12",
+        "proxy-addr": "~2.0.7",
+        "qs": "6.13.0",
+        "range-parser": "~1.2.1",
+        "safe-buffer": "5.2.1",
+        "send": "0.19.0",
+        "serve-static": "1.16.2",
+        "setprototypeof": "1.2.0",
+        "statuses": "2.0.1",
+        "type-is": "~1.6.18",
+        "utils-merge": "1.0.1",
+        "vary": "~1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.10.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/finalhandler": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/finalhandler/-/finalhandler-1.3.1.tgz",
+      "integrity": "sha512-6BN9trH7bp3qvnrRyzsBz+g3lZxTNZTbVO2EV1CS0WIcDbawYVdYvGflME/9QP0h0pYlCDBCTjYa9nZzMDpyxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "on-finished": "2.4.1",
+        "parseurl": "~1.3.3",
+        "statuses": "2.0.1",
+        "unpipe": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
       }
     },
     "node_modules/follow-redirects": {
@@ -221,6 +604,106 @@
         "node": ">= 6"
       }
     },
+    "node_modules/forwarded": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/forwarded/-/forwarded-0.2.0.tgz",
+      "integrity": "sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/fresh": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
+      "integrity": "sha512-zJ2mQYM18rEFOudeV4GShTGIQ7RbzA7ozbU9I/XBpm7kqgMywgmylMwXHxZJmkVoYkna9d2pVXVXPdYTP9ej8Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.2.7",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
+      "integrity": "sha512-VW6Pxhsrk0KAOqs3WEd0klDiF/+V7gQOpAvY1jVU/LHmaD/kQO4523aiJuikX/QAKYiW6x8Jh+RJej1almdtCA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.0.0",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.0",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
+      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -254,6 +737,15 @@
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "license": "ISC"
+    },
+    "node_modules/ipaddr.js": {
+      "version": "1.9.1",
+      "resolved": "https://registry.npmjs.org/ipaddr.js/-/ipaddr.js-1.9.1.tgz",
+      "integrity": "sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.10"
+      }
     },
     "node_modules/is-docker": {
       "version": "3.0.0",
@@ -303,6 +795,54 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/media-typer": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
+      "integrity": "sha512-dq+qelQ9akHpcOl/gUVRTxVIOkAJ1wR3QAvb4RsVjS8oVoFjDGTc679wJYmUmknUF5HwMLOgb5O+a3KxfWapPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/merge-descriptors": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/merge-descriptors/-/merge-descriptors-1.0.3.tgz",
+      "integrity": "sha512-gaNvAS7TZ897/rVaZ0nMtAyxNyi/pdbjbAwUpFQpN70GqnVfOiXpeUUMKRBmzXaSQ8DdTX4/0ms62r2K+hE6mQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-1.6.0.tgz",
+      "integrity": "sha512-x0Vn8spI+wuJ1O6S7gnbaQg8Pxh4NNHb7KSINmEWKiPE4RKOplvijn+NkmYmmRgP68mc70j2EbeTFRsrswaQeg==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -324,6 +864,45 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/ms": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+      "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
+      "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/object-inspect": {
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
+      "integrity": "sha512-kDCGIbxkDSXE3euJZZXzc6to7fCrKHNI/hSRQnRuQ+BWjFNzZwiFF8fj/6o2t2G9/jTj8PSIYTfCLelLZEeRpA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/on-finished": {
+      "version": "2.4.1",
+      "resolved": "https://registry.npmjs.org/on-finished/-/on-finished-2.4.1.tgz",
+      "integrity": "sha512-oVlzkg3ENAhCk2zdv7IJwd/QUD4z2RxRwpkcGY8psCVcCYZNq4wYnVWALHM+brtuJjePWiYF/ClmuDr8Ch5+kg==",
+      "license": "MIT",
+      "dependencies": {
+        "ee-first": "1.1.1"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
     "node_modules/open": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -342,11 +921,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/parseurl": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/parseurl/-/parseurl-1.3.3.tgz",
+      "integrity": "sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/path-to-regexp": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-0.1.12.tgz",
+      "integrity": "sha512-RA1GjUVMnvYFxuqovrEqZoxxW5NUZqbwKtYz/Tt7nXerk0LbLblQmrsgdeOxV5SFHf0UDggjS/bSeOZwt1pmEQ==",
+      "license": "MIT"
+    },
+    "node_modules/proxy-addr": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
+      "integrity": "sha512-llQsMLSUDUPT44jdrU/O37qlnifitDP+ZwrmmZcoSKyLKvtZxpyV0n2/bD/N4tBAAZ/gJEdZU7KMraoK1+XYAg==",
+      "license": "MIT",
+      "dependencies": {
+        "forwarded": "0.2.0",
+        "ipaddr.js": "1.9.1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
       "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==",
       "license": "MIT"
+    },
+    "node_modules/qs": {
+      "version": "6.13.0",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.13.0.tgz",
+      "integrity": "sha512-+38qI9SOr8tfZ4QmJNplMUxqjbe7LKvvZgWdExBOmd+egZTtjLB67Gu0HRX3u/XOq7UU2Nx6nsjvS16Z9uwfpg==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "side-channel": "^1.0.6"
+      },
+      "engines": {
+        "node": ">=0.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/range-parser": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/raw-body": {
       "version": "3.0.0",
@@ -375,17 +1006,163 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
       "license": "MIT"
     },
+    "node_modules/send": {
+      "version": "0.19.0",
+      "resolved": "https://registry.npmjs.org/send/-/send-0.19.0.tgz",
+      "integrity": "sha512-dW41u5VfLXu8SJh5bwRmyYUbAoSB3c9uQh6L8h/KtsFREPWpbX1lrljJo186Jc4nmci/sGUZ9a0a0J2zgfq2hw==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "2.6.9",
+        "depd": "2.0.0",
+        "destroy": "1.2.0",
+        "encodeurl": "~1.0.2",
+        "escape-html": "~1.0.3",
+        "etag": "~1.8.1",
+        "fresh": "0.5.2",
+        "http-errors": "2.0.0",
+        "mime": "1.6.0",
+        "ms": "2.1.3",
+        "on-finished": "2.4.1",
+        "range-parser": "~1.2.1",
+        "statuses": "2.0.1"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/send/node_modules/encodeurl": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha512-TPJXq8JqFaVYm2CWmPvnP2Iyo4ZSM7/QKcSmuMLDObfpH5fi7RUGmd/rTDf+rut/saiDiQEeVTNgAmJEdAOx0w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/send/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/serve-static": {
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/serve-static/-/serve-static-1.16.2.tgz",
+      "integrity": "sha512-VqpjJZKadQB/PEbEwvFdO43Ax5dFBZ2UECszz8bQ7pi7wt//PWe1P6MN7eCnjsatYtBT6EuiClbjSWP2WrIoTw==",
+      "license": "MIT",
+      "dependencies": {
+        "encodeurl": "~2.0.0",
+        "escape-html": "~1.0.3",
+        "parseurl": "~1.3.3",
+        "send": "0.19.0"
+      },
+      "engines": {
+        "node": ">= 0.8.0"
+      }
+    },
     "node_modules/setprototypeof": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/setprototypeof/-/setprototypeof-1.2.0.tgz",
       "integrity": "sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==",
       "license": "ISC"
+    },
+    "node_modules/side-channel": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
+      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3",
+        "side-channel-list": "^1.0.0",
+        "side-channel-map": "^1.0.1",
+        "side-channel-weakmap": "^1.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-list": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/side-channel-list/-/side-channel-list-1.0.0.tgz",
+      "integrity": "sha512-FCLHtRD/gnpCiCHEiJLOwdmFP+wzCmDEkc9y7NsYxeF4u7Btsn1ZuwgwJGxImImHicJArLP4R0yX4c2KCrMrTA==",
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-map": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/side-channel-map/-/side-channel-map-1.0.1.tgz",
+      "integrity": "sha512-VCjCNfgMsby3tTdo02nbjtM/ewra6jPHmpThenkTYh8pG9ucZ/1P8So4u4FGBek/BjpOVsDCMoLA/iuBKIFXRA==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/side-channel-weakmap": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/side-channel-weakmap/-/side-channel-weakmap-1.0.2.tgz",
+      "integrity": "sha512-WPS/HvHQTYnHisLo9McqBHOJk2FkHO/tlpvldyrnem4aeQp4hai3gythswg6p01oSoTl58rcpiFAjF2br2Ak2A==",
+      "license": "MIT",
+      "dependencies": {
+        "call-bound": "^1.0.2",
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.5",
+        "object-inspect": "^1.13.3",
+        "side-channel-map": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
     },
     "node_modules/statuses": {
       "version": "2.0.1",
@@ -403,6 +1180,19 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/type-is": {
+      "version": "1.6.18",
+      "resolved": "https://registry.npmjs.org/type-is/-/type-is-1.6.18.tgz",
+      "integrity": "sha512-TkRKr9sUTxEH8MdfuCSP7VizJyzRNMjj2J2do2Jr3Kym598JVdEksuzPQCnlFPW4ky9Q+iA+ma9BGm06XQBy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "media-typer": "0.3.0",
+        "mime-types": "~2.1.24"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/typescript": {
@@ -430,6 +1220,24 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unpipe/-/unpipe-1.0.0.tgz",
       "integrity": "sha512-pjy2bYhSsufwWlKwPc+l3cN7+wuJlK6uz0YdJEOlQDbl6jo/YlPi4mb8agUkVC8BF7V8NuzeyPNqRksA3hztKQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/utils-merge": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
+      "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "@google-cloud/storage": "^7.15.0",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
+        "body-parser": "^1.20.3",
         "dotenv": "^16.4.7",
         "express": "^4.21.2",
         "open": "^10.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
+        "@google-cloud/storage": "^7.15.0",
         "@modelcontextprotocol/sdk": "^1.0.4",
         "axios": "^1.7.9",
         "dotenv": "^16.4.7",
@@ -26,6 +27,75 @@
         "typescript": "^5.7.2"
       }
     },
+    "node_modules/@google-cloud/paginator": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/@google-cloud/paginator/-/paginator-5.0.2.tgz",
+      "integrity": "sha512-DJS3s0OVH4zFDB1PzjxAsHqJT6sKVbRwwML0ZBP9PbU7Yebtu/7SWMRzvO2J3nUi9pRNITCfu4LJeooM2w4pjg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "arrify": "^2.0.0",
+        "extend": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/projectify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/projectify/-/projectify-4.0.0.tgz",
+      "integrity": "sha512-MmaX6HeSvyPbWGwFq7mXdo0uQZLGBYCwziiLIGq5JVX+/bdI3SAq6bP98trV5eTWfLuvsMcIC1YJOF2vfteLFA==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@google-cloud/promisify": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/promisify/-/promisify-4.0.0.tgz",
+      "integrity": "sha512-Orxzlfb9c67A15cq2JQEyVc7wEsmFBmHjZWZYQMUyJ1qivXyMwdyNOs9odi79hze+2zqdTtu1E19IM/FtqZ10g==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@google-cloud/storage/-/storage-7.15.0.tgz",
+      "integrity": "sha512-/j/+8DFuEOo33fbdX0V5wjooOoFahEaMEdImHBmM2tH9MPHJYNtmXOf2sGUmZmiufSukmBEvdlzYgDkkgeBiVQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@google-cloud/paginator": "^5.0.0",
+        "@google-cloud/projectify": "^4.0.0",
+        "@google-cloud/promisify": "^4.0.0",
+        "abort-controller": "^3.0.0",
+        "async-retry": "^1.3.3",
+        "duplexify": "^4.1.3",
+        "fast-xml-parser": "^4.4.1",
+        "gaxios": "^6.0.2",
+        "google-auth-library": "^9.6.3",
+        "html-entities": "^2.5.2",
+        "mime": "^3.0.0",
+        "p-limit": "^3.0.1",
+        "retry-request": "^7.0.0",
+        "teeny-request": "^9.0.0",
+        "uuid": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@google-cloud/storage/node_modules/mime": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
+      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/@modelcontextprotocol/sdk": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.0.4.tgz",
@@ -35,6 +105,15 @@
         "content-type": "^1.0.5",
         "raw-body": "^3.0.0",
         "zod": "^3.23.8"
+      }
+    },
+    "node_modules/@tootallnate/once": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-2.0.0.tgz",
+      "integrity": "sha512-XCuKFP5PS55gnMVu3dty8KPatLqUoy/ZYzDzAGCQ8JNFCkLXzmI7vNHCR+XpbZaMWQK/vQubr7PkYq8g470J/A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 10"
       }
     },
     "node_modules/@types/body-parser": {
@@ -47,6 +126,12 @@
         "@types/connect": "*",
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/caseless": {
+      "version": "0.12.5",
+      "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
+      "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
     },
     "node_modules/@types/connect": {
       "version": "3.4.38",
@@ -112,7 +197,6 @@
       "version": "22.10.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-22.10.2.tgz",
       "integrity": "sha512-Xxr6BBRCAOQixvonOye19wnzyDiUtTeqldOOmj3CkeblonbccA12PFwlufvRdrpjXxqnmUaeiU5EOA+7s5diUQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.20.0"
@@ -131,6 +215,33 @@
       "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/@types/request": {
+      "version": "2.48.12",
+      "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.12.tgz",
+      "integrity": "sha512-G3sY+NpsA9jnwm0ixhAFQSJ3Q9JkpLZpJbI3GMv0mIAT0y3mRabYeINzal5WOChIiaTEGQYlHOKgkaM9EisWHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/caseless": "*",
+        "@types/node": "*",
+        "@types/tough-cookie": "*",
+        "form-data": "^2.5.0"
+      }
+    },
+    "node_modules/@types/request/node_modules/form-data": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.2.tgz",
+      "integrity": "sha512-GgwY0PS7DbXqajuGf4OYlsrIu3zgxD6Vvql43IBhm6MahqA5SK/7mwhtNj2AdH2z35YR34ujJ7BN+3fFC3jP5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.6",
+        "mime-types": "^2.1.12",
+        "safe-buffer": "^5.2.1"
+      },
+      "engines": {
+        "node": ">= 0.12"
+      }
     },
     "node_modules/@types/send": {
       "version": "0.17.4",
@@ -155,6 +266,24 @@
         "@types/send": "*"
       }
     },
+    "node_modules/@types/tough-cookie": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.5.tgz",
+      "integrity": "sha512-/Ad8+nIOV7Rl++6f1BdKxFSMgmoqEoYbHRpPcx3JEfv8VRsQe9Z4mCXeJBzxs7mbHY/XOZZuXlRNfhpVPbs6ZA==",
+      "license": "MIT"
+    },
+    "node_modules/abort-controller": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/abort-controller/-/abort-controller-3.0.0.tgz",
+      "integrity": "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg==",
+      "license": "MIT",
+      "dependencies": {
+        "event-target-shim": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=6.5"
+      }
+    },
     "node_modules/accepts": {
       "version": "1.3.8",
       "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
@@ -168,11 +297,38 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.3.tgz",
+      "integrity": "sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/array-flatten": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-1.1.1.tgz",
       "integrity": "sha512-PCVAQswWemu6UdxsDFFX/+gVeYqKAod3D3UVm91jHwynguOwAvYPhx8nNlM++NqRcK6CxxpUafjmhIdKiHibqg==",
       "license": "MIT"
+    },
+    "node_modules/arrify": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/arrify/-/arrify-2.0.1.tgz",
+      "integrity": "sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/async-retry": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/async-retry/-/async-retry-1.3.3.tgz",
+      "integrity": "sha512-wfr/jstw9xNi/0teMHrRW7dsz3Lt5ARhYNZ2ewpadnhaIp5mbALhOAP+EAdsC7t4Z6wqsDVv9+W6gm1Dk9mEyw==",
+      "license": "MIT",
+      "dependencies": {
+        "retry": "0.13.1"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -189,6 +345,35 @@
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
         "proxy-from-env": "^1.1.0"
+      }
+    },
+    "node_modules/base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/bignumber.js": {
+      "version": "9.1.2",
+      "resolved": "https://registry.npmjs.org/bignumber.js/-/bignumber.js-9.1.2.tgz",
+      "integrity": "sha512-2/mKyZH9K85bzOEfhXDBFZTGd1CTs+5IHpeFQo9luiBG7hghdC851Pj2WAhb6E3R6b9tZj/XKhbg4fum+Kepug==",
+      "license": "MIT",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/body-parser": {
@@ -241,6 +426,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/buffer-equal-constant-time": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/buffer-equal-constant-time/-/buffer-equal-constant-time-1.0.1.tgz",
+      "integrity": "sha512-zRpUiDwd/xk6ADqPMATG8vc9VPrkck7T07OIx0gnjmJAnHnTVXNQG3vfvWNuiZIkwu9KrKdA1iJKfsfTVxE6NA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/bundle-name": {
       "version": "4.1.0",
@@ -446,6 +637,27 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/duplexify": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-4.1.3.tgz",
+      "integrity": "sha512-M3BmBhwJRZsSx38lZyhE53Csddgzl5R7xGJNk7CVddZD6CcmwMCH8J+7AprIrQKH7TonKxaCjcv27Qmf+sQ+oA==",
+      "license": "MIT",
+      "dependencies": {
+        "end-of-stream": "^1.4.1",
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1",
+        "stream-shift": "^1.0.2"
+      }
+    },
+    "node_modules/ecdsa-sig-formatter": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/ecdsa-sig-formatter/-/ecdsa-sig-formatter-1.0.11.tgz",
+      "integrity": "sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
     "node_modules/ee-first": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ee-first/-/ee-first-1.1.1.tgz",
@@ -459,6 +671,15 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "license": "MIT",
+      "dependencies": {
+        "once": "^1.4.0"
       }
     },
     "node_modules/es-define-property": {
@@ -506,6 +727,15 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/event-target-shim": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/event-target-shim/-/event-target-shim-5.0.1.tgz",
+      "integrity": "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/express": {
       "version": "4.21.2",
       "resolved": "https://registry.npmjs.org/express/-/express-4.21.2.tgz",
@@ -550,6 +780,34 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
+    },
+    "node_modules/fast-xml-parser": {
+      "version": "4.5.1",
+      "resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.5.1.tgz",
+      "integrity": "sha512-y655CeyUQ+jj7KBbYMc4FG01V8ZQqjN+gDYGJ50RtfsUB8iG9AmwmwoAgeKLJdmueKKMrH1RJ7yXHTSoczdv5w==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/NaturalIntelligence"
+        },
+        {
+          "type": "paypal",
+          "url": "https://paypal.me/naturalintelligence"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "strnum": "^1.0.5"
+      },
+      "bin": {
+        "fxparser": "src/cli/cli.js"
       }
     },
     "node_modules/finalhandler": {
@@ -631,6 +889,48 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/gaxios": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/gaxios/-/gaxios-6.7.1.tgz",
+      "integrity": "sha512-LDODD4TMYx7XXdpwxAVRAIAuB0bzv0s+ywFonY46k126qzQHT9ygyoa9tncmOiQmmDrik65UYsEkv3lbfqQ3yQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "extend": "^3.0.2",
+        "https-proxy-agent": "^7.0.1",
+        "is-stream": "^2.0.0",
+        "node-fetch": "^2.6.9",
+        "uuid": "^9.0.1"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/gaxios/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/gcp-metadata": {
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/gcp-metadata/-/gcp-metadata-6.1.0.tgz",
+      "integrity": "sha512-Jh/AIwwgaxan+7ZUUmRLCjtchyDiqh4KjBJ5tW3plBZb5iL/BPcso8A5DlzeD9qlw0duCamnNdpFjxwaT0KyKg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "json-bigint": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/get-intrinsic": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.7.tgz",
@@ -668,6 +968,23 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/google-auth-library": {
+      "version": "9.15.0",
+      "resolved": "https://registry.npmjs.org/google-auth-library/-/google-auth-library-9.15.0.tgz",
+      "integrity": "sha512-7ccSEJFDFO7exFbO6NRyC+xH8/mZ1GZGG2xxx9iHxZWcjUjJpjWxIMw3cofAKcueZ6DATiukmmprD7yavQHOyQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "base64-js": "^1.3.0",
+        "ecdsa-sig-formatter": "^1.0.11",
+        "gaxios": "^6.1.1",
+        "gcp-metadata": "^6.1.0",
+        "gtoken": "^7.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/gopd": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
@@ -678,6 +995,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/gtoken": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/gtoken/-/gtoken-7.1.0.tgz",
+      "integrity": "sha512-pCcEwRi+TKpMlxAQObHDQ56KawURgyAf6jtIY046fJ5tIv3zDe/LEIubckAO8fj6JnAxLdmWkUfNyulQ2iKdEw==",
+      "license": "MIT",
+      "dependencies": {
+        "gaxios": "^6.0.0",
+        "jws": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/has-symbols": {
@@ -704,6 +1034,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/html-entities": {
+      "version": "2.5.2",
+      "resolved": "https://registry.npmjs.org/html-entities/-/html-entities-2.5.2.tgz",
+      "integrity": "sha512-K//PSRMQk4FZ78Kyau+mZurHn3FH0Vwr+H36eE0rPbeYkRRi9YxceYPhuN60UwWorxyKHhqoAJl2OFKa4BVtaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/mdevils"
+        },
+        {
+          "type": "patreon",
+          "url": "https://patreon.com/mdevils"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/http-errors": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-2.0.0.tgz",
@@ -719,6 +1065,91 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-5.0.0.tgz",
+      "integrity": "sha512-n2hY8YdoRE1i7r6M0w9DIw5GgZN0G25P8zLCRQ8rjXtTU3vsNFBI/vWK/UIeE6g5MUUz6avwAPXmL6Fy9D/90w==",
+      "license": "MIT",
+      "dependencies": {
+        "@tootallnate/once": "2",
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/http-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/https-proxy-agent/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/iconv-lite": {
       "version": "0.6.3",
@@ -780,6 +1211,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-stream": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-2.0.1.tgz",
+      "integrity": "sha512-hFoiJiTl63nn+kstHGBtewWSKnQLpyb155KHheA1l39uvtO9nWIop1p3udqPcUd/xbF1VLMO4n7OI6p7RbngDg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-wsl": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.0.tgz",
@@ -793,6 +1236,36 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/json-bigint": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-bigint/-/json-bigint-1.0.0.tgz",
+      "integrity": "sha512-SiPv/8VpZuWbvLSMtTDU8hEfrZWg/mH/nV/b4o0CYbSxu1UIQPLdwKOCIyLQX+VIPO5vrLX3i8qtqFyhdPSUSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/jwa": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/jwa/-/jwa-2.0.0.tgz",
+      "integrity": "sha512-jrZ2Qx916EA+fq9cEAeCROWPTfCwi1IVHqT2tapuqLEVVDKFDENFw1oL+MwrTvH6msKxsd1YTDVw6uKEcsrLEA==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-equal-constant-time": "1.0.1",
+        "ecdsa-sig-formatter": "1.0.11",
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "node_modules/jws": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jws/-/jws-4.0.0.tgz",
+      "integrity": "sha512-KDncfTmOZoOMTFG4mBlG0qUIOlc03fmzH+ru6RgYVZhPkyiy/92Owlt/8UEN+a4TXR1FQetfIpJE8ApdvdVxTg==",
+      "license": "MIT",
+      "dependencies": {
+        "jwa": "^2.0.0",
+        "safe-buffer": "^5.0.1"
       }
     },
     "node_modules/math-intrinsics": {
@@ -879,6 +1352,26 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/node-fetch": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.7.0.tgz",
+      "integrity": "sha512-c4FRfUm/dbcWZ7U+1Wq0AwCyFL+3nt2bEw05wfxSz+DWpWsitgmSgYmy2dQdWyKC1694ELPqMs/YzUSNozLt8A==",
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-url": "^5.0.0"
+      },
+      "engines": {
+        "node": "4.x || >=6.0.0"
+      },
+      "peerDependencies": {
+        "encoding": "^0.1.0"
+      },
+      "peerDependenciesMeta": {
+        "encoding": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/object-inspect": {
       "version": "1.13.3",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.3.tgz",
@@ -903,6 +1396,15 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
+      "license": "ISC",
+      "dependencies": {
+        "wrappy": "1"
+      }
+    },
     "node_modules/open": {
       "version": "10.1.0",
       "resolved": "https://registry.npmjs.org/open/-/open-10.1.0.tgz",
@@ -916,6 +1418,21 @@
       },
       "engines": {
         "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-limit": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
+      "integrity": "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "yocto-queue": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=10"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -992,6 +1509,43 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "license": "MIT",
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/retry-request": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/retry-request/-/retry-request-7.0.2.tgz",
+      "integrity": "sha512-dUOvLMJ0/JJYEn8NrpOaGNE7X3vpI5XlZS/u0ANjqtcZVKnIxP7IgCFwrKTxENw29emmwug53awKtaMm4i9g5w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/request": "^2.48.8",
+        "extend": "^3.0.2",
+        "teeny-request": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
       }
     },
     "node_modules/run-applescript": {
@@ -1173,6 +1727,119 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/stream-events": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/stream-events/-/stream-events-1.0.5.tgz",
+      "integrity": "sha512-E1GUzBSgvct8Jsb3v2X15pjzN1tYebtbLaMg+eBOUOAxgbLoSbT2NS91ckc5lJD1KfLjId+jXJRgo0qnV5Nerg==",
+      "license": "MIT",
+      "dependencies": {
+        "stubs": "^3.0.0"
+      }
+    },
+    "node_modules/stream-shift": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
+      "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
+      "license": "MIT"
+    },
+    "node_modules/string_decoder": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+      "license": "MIT",
+      "dependencies": {
+        "safe-buffer": "~5.2.0"
+      }
+    },
+    "node_modules/strnum": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
+      "integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
+      "license": "MIT"
+    },
+    "node_modules/stubs": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/stubs/-/stubs-3.0.0.tgz",
+      "integrity": "sha512-PdHt7hHUJKxvTCgbKX9C1V/ftOcjJQgz8BZwNfV5c4B6dcGqlpelTbJ999jBGZ2jYiPAwcX5dP6oBwVlBlUbxw==",
+      "license": "MIT"
+    },
+    "node_modules/teeny-request": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/teeny-request/-/teeny-request-9.0.0.tgz",
+      "integrity": "sha512-resvxdc6Mgb7YEThw6G6bExlXKkv6+YbuzGg9xuXxSgxJF7Ozs+o8Y9+2R3sArdWdW8nOokoQb1yrpFB0pQK2g==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "http-proxy-agent": "^5.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "node-fetch": "^2.6.9",
+        "stream-events": "^1.0.5",
+        "uuid": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/teeny-request/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/teeny-request/node_modules/debug": {
+      "version": "4.4.0",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.0.tgz",
+      "integrity": "sha512-6WTZ/IxCY/T6BALoZHaE4ctp9xm+Z5kY/pzYaCHRFeyVhojxlrm+46y68HA6hr0TcwEssoxNiDEUJQjfPZ/RYA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/teeny-request/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/teeny-request/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
+    "node_modules/teeny-request/node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/toidentifier": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/toidentifier/-/toidentifier-1.0.1.tgz",
@@ -1181,6 +1848,12 @@
       "engines": {
         "node": ">=0.6"
       }
+    },
+    "node_modules/tr46": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-0.0.3.tgz",
+      "integrity": "sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==",
+      "license": "MIT"
     },
     "node_modules/type-is": {
       "version": "1.6.18",
@@ -1213,7 +1886,6 @@
       "version": "6.20.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
       "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unpipe": {
@@ -1225,6 +1897,12 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
     "node_modules/utils-merge": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/utils-merge/-/utils-merge-1.0.1.tgz",
@@ -1234,6 +1912,15 @@
         "node": ">= 0.4.0"
       }
     },
+    "node_modules/uuid": {
+      "version": "8.3.2",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -1241,6 +1928,40 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
+      "integrity": "sha512-2JAn3z8AR6rjK8Sm8orRC0h/bcl/DqL7tRPdGZ4I1CjdF+EaMLmYxBHyXuKL849eucPFhvBoxMsflfOb8kxaeQ==",
+      "license": "BSD-2-Clause"
+    },
+    "node_modules/whatwg-url": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-5.0.0.tgz",
+      "integrity": "sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==",
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "~0.0.3",
+        "webidl-conversions": "^3.0.0"
+      }
+    },
+    "node_modules/wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
+      "license": "ISC"
+    },
+    "node_modules/yocto-queue": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
+      "integrity": "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/zod": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "build"
   ],
   "dependencies": {
+    "@google-cloud/storage": "^7.15.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
     "dotenv": "^16.4.7",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@google-cloud/storage": "^7.15.0",
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
+    "body-parser": "^1.20.3",
     "dotenv": "^16.4.7",
     "express": "^4.21.2",
     "open": "^10.1.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "@modelcontextprotocol/sdk": "^1.0.4",
     "axios": "^1.7.9",
     "dotenv": "^16.4.7",
+    "express": "^4.21.2",
     "open": "^10.1.0",
     "zod": "^3.24.1"
   },
@@ -35,6 +36,7 @@
   "license": "MIT",
   "devDependencies": {
     "@types/dotenv": "^6.1.1",
+    "@types/express": "^5.0.0",
     "@types/node": "^22.10.2",
     "typescript": "^5.7.2"
   }

--- a/src/gcs/gcsClient.ts
+++ b/src/gcs/gcsClient.ts
@@ -1,0 +1,96 @@
+import { Storage, File } from "@google-cloud/storage";
+
+// Example .env file:
+// GCS_PROJECT_ID=your-project-id
+// GCS_CLIENT_EMAIL=your-service-account@project.iam.gserviceaccount.com
+// GCS_PRIVATE_KEY=-----BEGIN PRIVATE KEY-----\nYourKeyHere\n-----END PRIVATE KEY-----\n
+interface GcsClientConfig {
+	privateKey?: string;
+	clientEmail?: string;
+	projectId?: string;
+}
+
+interface UploadOptions {
+	contentType?: string;
+	destination?: string;
+}
+
+export class GcsClient {
+	private readonly storage: Storage;
+	private readonly bucketName = "stability-ai-mcp-server";
+
+	constructor(config?: GcsClientConfig) {
+		const credentials =
+			config?.privateKey && config?.clientEmail
+				? {
+						type: "service_account",
+						private_key: config.privateKey.replace(/\\n/g, "\n"),
+						client_email: config.clientEmail,
+						project_id: config.projectId,
+					}
+				: undefined;
+
+		this.storage = new Storage({
+			credentials,
+			projectId: config?.projectId,
+		});
+
+		// Initialize bucket
+		this.initializeBucket().catch((error) => {
+			console.error("Warning: Bucket initialization error:", error.message);
+		});
+	}
+
+	private async initializeBucket(): Promise<void> {
+		try {
+			const [exists] = await this.storage.bucket(this.bucketName).exists();
+			if (!exists) {
+				await this.storage.createBucket(this.bucketName);
+				console.log(`Bucket ${this.bucketName} created successfully.`);
+			} else {
+				console.log(`Bucket ${this.bucketName} already exists.`);
+			}
+		} catch (error) {
+			throw new Error(`Failed to initialize bucket: ${error}`);
+		}
+	}
+
+	async uploadFile(filePath: string, options?: UploadOptions): Promise<File> {
+		try {
+			const bucket = this.storage.bucket(this.bucketName);
+			const destination = options?.destination || filePath.split("/").pop();
+
+			const [file] = await bucket.upload(filePath, {
+				destination,
+				contentType: options?.contentType,
+			});
+
+			return file;
+		} catch (error) {
+			throw new Error(`Failed to upload file: ${error}`);
+		}
+	}
+
+	async downloadFile(fileName: string, destinationPath: string): Promise<void> {
+		try {
+			const bucket = this.storage.bucket(this.bucketName);
+			const file = bucket.file(fileName);
+
+			await file.download({
+				destination: destinationPath,
+			});
+		} catch (error) {
+			throw new Error(`Failed to download file: ${error}`);
+		}
+	}
+
+	async listFiles(prefix?: string): Promise<File[]> {
+		try {
+			const bucket = this.storage.bucket(this.bucketName);
+			const [files] = await bucket.getFiles({ prefix });
+			return files;
+		} catch (error) {
+			throw new Error(`Failed to list files: ${error}`);
+		}
+	}
+}

--- a/src/gcs/gcsClient.ts
+++ b/src/gcs/gcsClient.ts
@@ -8,6 +8,7 @@ interface GcsClientConfig {
 	privateKey?: string;
 	clientEmail?: string;
 	projectId?: string;
+	bucketName?: string;
 }
 
 interface UploadOptions {
@@ -17,9 +18,10 @@ interface UploadOptions {
 
 export class GcsClient {
 	private readonly storage: Storage;
-	private readonly bucketName = "stability-ai-mcp-server";
+	bucketName: string;
 
 	constructor(config?: GcsClientConfig) {
+		this.bucketName = config?.bucketName as string;
 		const credentials =
 			config?.privateKey && config?.clientEmail
 				? {
@@ -63,6 +65,7 @@ export class GcsClient {
 			const [file] = await bucket.upload(filePath, {
 				destination,
 				contentType: options?.contentType,
+				public: true,
 			});
 
 			return file;

--- a/src/index.ts
+++ b/src/index.ts
@@ -232,7 +232,6 @@ function printUsage() {
 	console.error("  --sse    Use SSE transport instead of stdio");
 }
 
-// Start the server
 async function main() {
 	const args = process.argv.slice(2);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,6 +2,7 @@
 
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
 import {
 	CallToolRequestSchema,
 	GetPromptRequestSchema,
@@ -51,6 +52,7 @@ import {
 } from "./tools/index.js";
 import { ResourceClient } from "./resources/resourceClient.js";
 import { prompts, injectPromptTemplate } from "./prompts/index.js";
+import http from "http";
 
 dotenv.config();
 
@@ -203,14 +205,96 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 	};
 });
 
+function printUsage() {
+	console.error("Usage: node build/index.js [--sse]");
+	console.error("Options:");
+	console.error("  --sse    Use SSE transport instead of stdio");
+}
+
+// Store the active transport
+let sseTransport: SSEServerTransport | null = null;
+
 // Start the server
 async function main() {
-	const transport = new StdioServerTransport();
-	await server.connect(transport);
-	console.error("stability-ai MCP Server running on stdio");
+	const args = process.argv.slice(2);
+
+	if (args.length > 1 || (args.length === 1 && args[0] !== "--sse")) {
+		printUsage();
+		throw new Error("Invalid arguments");
+	}
+
+	const useSSE = args.includes("--sse");
+
+	if (useSSE) {
+		const httpServer = http.createServer(async (req, res) => {
+			console.log(`${req.method} request to ${req.url}`);
+
+			// Add CORS headers
+			res.setHeader("Access-Control-Allow-Origin", "*");
+			res.setHeader("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
+			res.setHeader("Access-Control-Allow-Headers", "Content-Type");
+
+			// Handle OPTIONS preflight
+			if (req.method === "OPTIONS") {
+				res.writeHead(204);
+				res.end();
+				return;
+			}
+
+			if (req.url?.startsWith("/sse")) {
+				if (req.method === "GET") {
+					console.log("SSE connection attempt received");
+
+					// Add error handler for the response
+					res.on("error", (error) => {
+						console.error("Response error:", error);
+					});
+
+					// Add close handler
+					res.on("close", () => {
+						sseTransport = null;
+						console.log("SSE connection closed");
+					});
+
+					sseTransport = new SSEServerTransport("/sse", res);
+
+					// Connect the server (this will call start() internally)
+					await server.connect(sseTransport);
+
+					console.log("SSE connection setup complete");
+				} else if (req.method === "POST") {
+					if (!sseTransport) {
+						res.writeHead(400);
+						res.end("No active SSE connection");
+						return;
+					}
+					// Let the transport handle the POST message directly
+					await sseTransport.handlePostMessage(req, res);
+				}
+			} else {
+				res.writeHead(404);
+				res.end();
+			}
+		});
+
+		// Add error handler for the server
+		httpServer.on("error", (error) => {
+			console.error("Server error:", error);
+		});
+
+		httpServer.listen(3020, () => {
+			console.error(
+				"stability-ai MCP Server running on SSE at http://localhost:3020"
+			);
+		});
+	} else {
+		const transport = new StdioServerTransport();
+		await server.connect(transport);
+		console.error("stability-ai MCP Server running on stdio");
+	}
 }
 
 main().catch((error) => {
-	console.error("Fatal error in main():", error);
+	console.error("Fatal error:", error);
 	process.exit(1);
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -249,6 +249,7 @@ async function main() {
 					privateKey: process.env.GCS_PRIVATE_KEY,
 					clientEmail: process.env.GCS_CLIENT_EMAIL,
 					projectId: process.env.GCS_PROJECT_ID,
+					bucketName: process.env.GCS_BUCKET_NAME,
 				},
 			}
 		: {

--- a/src/resources/filesystemResourceClient.ts
+++ b/src/resources/filesystemResourceClient.ts
@@ -1,0 +1,90 @@
+import { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { ResourceClient } from "./resourceClient.js";
+import * as fs from "fs";
+
+export class FilesystemResourceClient extends ResourceClient {
+	constructor(private readonly imageStorageDirectory: string) {
+		super();
+	}
+
+	async listResources(): Promise<Resource[]> {
+		const resources = await fs.promises.readdir(this.imageStorageDirectory, {
+			withFileTypes: true,
+		});
+
+		return resources.map((resource) => {
+			const uri = `file://${this.imageStorageDirectory}/${resource.name}`;
+			const mimeType = this.getMimeType(resource.name);
+			return { uri, name: resource.name, mimeType };
+		});
+	}
+
+	async readResource(uri: string): Promise<Resource> {
+		try {
+			const filePath = uri.replace("file://", "");
+
+			if (!fs.existsSync(filePath)) {
+				throw new Error("Resource file not found");
+			}
+
+			const content = await fs.promises.readFile(filePath);
+			const name = filePath.split("/").pop();
+
+			if (!name) {
+				throw new Error("Invalid file path");
+			}
+
+			const base64Content = Buffer.from(content).toString("base64");
+
+			return {
+				uri,
+				name,
+				blob: base64Content,
+				mimeType: this.getMimeType(name),
+			};
+		} catch (error) {
+			if (error instanceof Error) {
+				throw new Error(`Failed to read resource: ${error.message}`);
+			}
+			throw new Error("Failed to read resource: Unknown error");
+		}
+	}
+
+	async createResource(uri: string, base64image: string): Promise<Resource> {
+		const filename = uri.split("/").pop();
+		if (!filename) {
+			throw new Error("Invalid file path");
+		}
+
+		const [name, ext] = filename.split(".");
+		let finalFilename = filename;
+
+		if (fs.existsSync(`${this.imageStorageDirectory}/${filename}`)) {
+			const randomString = Math.random().toString(36).substring(2, 7);
+			finalFilename = `${name}-${randomString}.${ext}`;
+		}
+
+		fs.writeFileSync(
+			`${this.imageStorageDirectory}/${finalFilename}`,
+			base64image,
+			"base64"
+		);
+
+		const fullUri = `file://${this.imageStorageDirectory}/${finalFilename}`;
+
+		return {
+			uri: fullUri,
+			name: finalFilename,
+			mimeType: this.getMimeType(finalFilename),
+			text: `Image ${finalFilename} successfully created at URI ${fullUri}.`,
+		};
+	}
+
+	async resourceToFile(uri: string): Promise<string> {
+		const filename = uri.split("/").pop();
+		if (!filename) {
+			throw new Error("Invalid file path");
+		}
+		return uri.replace("file://", "");
+	}
+}

--- a/src/resources/gcsResourceClient.ts
+++ b/src/resources/gcsResourceClient.ts
@@ -22,14 +22,20 @@ export class GcsResourceClient extends ResourceClient {
 
 	async listResources(context?: ResourceContext): Promise<Resource[]> {
 		const files = await this.gcsClient.listFiles(this.getPrefix(context));
-		return files.map((file) => ({
-			uri: `gcs://${file.name}`,
-			name: file.name,
-			mimeType: this.getMimeType(file.name),
-		}));
+		return files.map((file) => {
+			const nameWithoutPrefix = file.name.replace(this.getPrefix(context), "");
+			return {
+				uri: `gcs://${nameWithoutPrefix}`,
+				name: nameWithoutPrefix,
+				mimeType: this.getMimeType(nameWithoutPrefix),
+			};
+		});
 	}
 
-	async readResource(uri: string, context?: ResourceContext): Promise<Resource> {
+	async readResource(
+		uri: string,
+		context?: ResourceContext
+	): Promise<Resource> {
 		try {
 			const filename = uri.replace("gcs://", "");
 			const tempFilePath = path.join(this.tempDir, filename);
@@ -58,7 +64,11 @@ export class GcsResourceClient extends ResourceClient {
 		}
 	}
 
-	async createResource(uri: string, base64image: string, context?: ResourceContext): Promise<Resource> {
+	async createResource(
+		uri: string,
+		base64image: string,
+		context?: ResourceContext
+	): Promise<Resource> {
 		const filename = uri.replace("gcs://", "");
 		if (!filename) {
 			throw new Error("Invalid file path");
@@ -91,14 +101,20 @@ export class GcsResourceClient extends ResourceClient {
 		};
 	}
 
-	async resourceToFile(uri: string, context?: ResourceContext): Promise<string> {
+	async resourceToFile(
+		uri: string,
+		context?: ResourceContext
+	): Promise<string> {
 		const filename = uri.replace("gcs://", "");
 		if (!filename) {
 			throw new Error("Invalid file path");
 		}
 
 		const tempFilePath = path.join(this.tempDir, filename);
-		await this.gcsClient.downloadFile(this.getPrefix(context) + filename, tempFilePath);
+		await this.gcsClient.downloadFile(
+			this.getPrefix(context) + filename,
+			tempFilePath
+		);
 
 		return tempFilePath;
 	}

--- a/src/resources/gcsResourceClient.ts
+++ b/src/resources/gcsResourceClient.ts
@@ -1,0 +1,105 @@
+import { Resource } from "@modelcontextprotocol/sdk/types.js";
+import { ResourceClient, ResourceContext } from "./resourceClient.js";
+import { GcsClient } from "../gcs/gcsClient.js";
+import * as fs from "fs";
+import * as os from "os";
+import * as path from "path";
+
+export class GcsResourceClient extends ResourceClient {
+	private readonly tempDir: string;
+	private ipAddress?: string;
+
+	constructor(private readonly gcsClient: GcsClient) {
+		super();
+		this.tempDir = fs.mkdtempSync(
+			path.join(os.tmpdir(), "stability-ai-mcp-server-gcs-resource-")
+		);
+	}
+
+	getPrefix(context?: ResourceContext): string {
+		return context?.requestorIpAddress + "/";
+	}
+
+	async listResources(context?: ResourceContext): Promise<Resource[]> {
+		const files = await this.gcsClient.listFiles(this.getPrefix(context));
+		return files.map((file) => ({
+			uri: `gcs://${file.name}`,
+			name: file.name,
+			mimeType: this.getMimeType(file.name),
+		}));
+	}
+
+	async readResource(uri: string, context?: ResourceContext): Promise<Resource> {
+		try {
+			const filename = uri.replace("gcs://", "");
+			const tempFilePath = path.join(this.tempDir, filename);
+
+			await this.gcsClient.downloadFile(
+				this.getPrefix(context) + filename,
+				tempFilePath
+			);
+			const content = await fs.promises.readFile(tempFilePath);
+			const base64Content = content.toString("base64");
+
+			// Clean up temp file
+			fs.unlinkSync(tempFilePath);
+
+			return {
+				uri,
+				name: filename,
+				blob: base64Content,
+				mimeType: this.getMimeType(filename),
+			};
+		} catch (error) {
+			if (error instanceof Error) {
+				throw new Error(`Failed to read resource: ${error.message}`);
+			}
+			throw new Error("Failed to read resource: Unknown error");
+		}
+	}
+
+	async createResource(uri: string, base64image: string, context?: ResourceContext): Promise<Resource> {
+		const filename = uri.replace("gcs://", "");
+		if (!filename) {
+			throw new Error("Invalid file path");
+		}
+
+		const [name, ext] = filename.split(".");
+		const randomString = Math.random().toString(36).substring(2, 7);
+		const finalFilename = `${name}-${randomString}.${ext}`;
+
+		// Write to temp file first
+		const tempFilePath = path.join(this.tempDir, finalFilename);
+		fs.writeFileSync(tempFilePath, base64image, "base64");
+
+		// Upload to GCS
+		await this.gcsClient.uploadFile(tempFilePath, {
+			destination: this.getPrefix(context) + finalFilename,
+			contentType: this.getMimeType(finalFilename),
+		});
+
+		// Clean up temp file
+		fs.unlinkSync(tempFilePath);
+
+		const fullUri = `gcs://${finalFilename}`;
+
+		return {
+			uri: fullUri,
+			name: finalFilename,
+			mimeType: this.getMimeType(finalFilename),
+			text: `Image ${finalFilename} successfully created at URI ${fullUri}.`,
+		};
+	}
+
+	async resourceToFile(uri: string, context?: ResourceContext): Promise<string> {
+		const filename = uri.replace("gcs://", "");
+		if (!filename) {
+			throw new Error("Invalid file path");
+		}
+
+		const tempFilePath = path.join(this.tempDir, filename);
+		await this.gcsClient.downloadFile(this.getPrefix(context) + filename, tempFilePath);
+
+		return tempFilePath;
+	}
+}

--- a/src/resources/resourceClient.ts
+++ b/src/resources/resourceClient.ts
@@ -1,96 +1,12 @@
 import { Resource } from "@modelcontextprotocol/sdk/types.js";
-import * as fs from "fs";
 
-export class ResourceClient {
-	constructor(private readonly imageStorageDirectory: string) {}
+export abstract class ResourceClient {
+	abstract listResources(context?: ResourceContext): Promise<Resource[]>;
+	abstract readResource(uri: string, context?: ResourceContext): Promise<Resource>;
+	abstract createResource(uri: string, base64image: string, context?: ResourceContext): Promise<Resource>;
+	abstract resourceToFile(uri: string, context?: ResourceContext): Promise<string>;
 
-	async listResources(): Promise<Resource[]> {
-		const resources = await fs.promises.readdir(this.imageStorageDirectory, {
-			withFileTypes: true,
-		});
-
-		return resources.map((resource) => {
-			const uri = `file://${this.imageStorageDirectory}/${resource.name}`;
-			const mimeType = this.getMimeType(resource.name);
-			return { uri, name: resource.name, mimeType };
-		});
-	}
-
-	async readResource(uri: string): Promise<Resource> {
-		try {
-			const filePath = uri.replace("file://", "");
-
-			// Check if file exists
-			if (!fs.existsSync(filePath)) {
-				throw new Error("Resource file not found");
-			}
-
-			const content = await fs.promises.readFile(filePath);
-			const name = filePath.split("/").pop();
-
-			if (!name) {
-				throw new Error("Invalid file path");
-			}
-
-			const base64Content = Buffer.from(content).toString("base64");
-
-			return {
-				uri,
-				name,
-				blob: base64Content,
-				mimeType: this.getMimeType(name),
-			};
-		} catch (error) {
-			if (error instanceof Error) {
-				throw new Error(`Failed to read resource: ${error.message}`);
-			}
-			throw new Error("Failed to read resource: Unknown error");
-		}
-	}
-
-	async createResource(uri: string, base64image: string) {
-		const filename = uri.split("/").pop();
-		if (!filename) {
-			throw new Error("Invalid file path");
-		}
-
-		// Split filename into name and extension
-		const [name, ext] = filename.split(".");
-		let finalFilename = filename;
-
-		// If file exists, append random string
-		if (fs.existsSync(`${this.imageStorageDirectory}/${filename}`)) {
-			const randomString = Math.random().toString(36).substring(2, 7);
-			finalFilename = `${name}-${randomString}.${ext}`;
-		}
-
-		fs.writeFileSync(
-			`${this.imageStorageDirectory}/${finalFilename}`,
-			base64image,
-			"base64"
-		);
-
-		const fullUri = `file://${this.imageStorageDirectory}/${finalFilename}`;
-
-		return {
-			uri: fullUri,
-			name: finalFilename,
-			mimeType: this.getMimeType(finalFilename),
-			text: `Image ${finalFilename} successfully created at URI ${fullUri}.`,
-		};
-	}
-
-	// Return a resource URI as a file path. In the stdio case, this is simply a matter of stripped out the file:// prefix.
-	// TODO: in the SSE case, we want to actually download the file from external storage and (temporarily) store it locally while we stream it to Stability. Also will need to handle deletion after the fact (maybe refactor to use a temp directory in both stdio and SSE cases)
-	async resourceToFile(uri: string) {
-		const filename = uri.split("/").pop();
-		if (!filename) {
-			throw new Error("Invalid file path");
-		}
-		return uri.replace("file://", "");
-	}
-
-	private getMimeType(filename: string): string {
+	protected getMimeType(filename: string): string {
 		const ext = filename.toLowerCase().split(".").pop();
 		switch (ext) {
 			case "jpg":
@@ -104,4 +20,8 @@ export class ResourceClient {
 				return "application/octet-stream";
 		}
 	}
+}
+
+export interface ResourceContext {
+	requestorIpAddress?: string;
 }

--- a/src/resources/resourceClientFactory.ts
+++ b/src/resources/resourceClientFactory.ts
@@ -16,6 +16,7 @@ export type ResourceClientConfig =
 				privateKey?: string;
 				clientEmail?: string;
 				projectId?: string;
+				bucketName?: string;
 			};
 	  };
 

--- a/src/resources/resourceClientFactory.ts
+++ b/src/resources/resourceClientFactory.ts
@@ -1,0 +1,40 @@
+import { ResourceClient } from "./resourceClient.js";
+import { FilesystemResourceClient } from "./filesystemResourceClient.js";
+import { GcsResourceClient } from "./gcsResourceClient.js";
+import { GcsClient } from "../gcs/gcsClient.js";
+
+let instance: ResourceClient | null = null;
+
+export type ResourceClientConfig =
+	| {
+			type: "filesystem";
+			imageStorageDirectory: string;
+	  }
+	| {
+			type: "gcs";
+			gcsConfig?: {
+				privateKey?: string;
+				clientEmail?: string;
+				projectId?: string;
+			};
+	  };
+
+export function initializeResourceClient(config: ResourceClientConfig) {
+	if (instance) {
+		throw new Error("ResourceClient has already been initialized");
+	}
+
+	if (config.type === "filesystem") {
+		instance = new FilesystemResourceClient(config.imageStorageDirectory);
+	} else {
+		const gcsClient = new GcsClient(config.gcsConfig);
+		instance = new GcsResourceClient(gcsClient);
+	}
+}
+
+export function getResourceClient(): ResourceClient {
+	if (!instance) {
+		throw new Error("ResourceClient has not been initialized");
+	}
+	return instance;
+}

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,10 +1,29 @@
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import express from "express";
+import express, { Request } from "express";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+import bodyParser from "body-parser";
+
+function getClientIp(req: Request): string {
+	return (
+		// Check X-Forwarded-For header first (when behind a proxy/load balancer)
+		req.get("x-forwarded-for")?.split(",")[0] ||
+		// Check X-Real-IP header (common with Nginx)
+		req.get("x-real-ip") ||
+		// Check req.ip (Express built-in, respects trust proxy setting)
+		req.ip ||
+		// Fallback to remoteAddress from the underlying socket
+		req.socket.remoteAddress ||
+		// Final fallback
+		"unknown"
+	);
+}
 
 export async function runSSEServer(server: Server) {
 	let sseTransport: SSEServerTransport | null = null;
 	const app = express();
+
+	// Used to allow parsing of the body of the request
+	app.use("/*", bodyParser.json());
 
 	app.get("/sse", async (req, res) => {
 		sseTransport = new SSEServerTransport("/messages", res);
@@ -15,9 +34,21 @@ export async function runSSEServer(server: Server) {
 		});
 	});
 
-	app.post("/messages", async (req, res) => {
+	app.post("/messages", async (req: Request, res) => {
 		if (sseTransport) {
-			await sseTransport.handlePostMessage(req, res);
+			// Parse the body and add the IP address
+			const body = req.body;
+			const params = req.body.params || {};
+			params._meta = {
+				ip: getClientIp(req),
+				headers: req.headers,
+			};
+			const enrichedBody = {
+				...body,
+				params,
+			};
+
+			await sseTransport.handlePostMessage(req, res, enrichedBody);
 		} else {
 			res.status(400).send("No active SSE connection");
 		}
@@ -25,7 +56,11 @@ export async function runSSEServer(server: Server) {
 
 	// Handle 404s for all other routes
 	app.use((req, res) => {
-		res.status(404).end();
+		res.status(404).json({
+			error: "Not Found",
+			message: `Route ${req.method} ${req.path} not found`,
+			timestamp: new Date().toISOString(),
+		});
 	});
 
 	app.listen(3020, () => {

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,0 +1,56 @@
+import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
+import http from "http";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+export async function runSSEServer(server: Server) {
+	// Store the active transport
+	let sseTransport: SSEServerTransport | null = null;
+
+	const httpServer = http.createServer(async (req, res) => {
+		console.log(`${req.method} request to ${req.url}`);
+
+		if (req.url?.startsWith("/sse")) {
+			if (req.method === "GET") {
+				console.log("SSE connection attempt received");
+
+				// Add error handler for the response
+				res.on("error", (error) => {
+					console.error("Response error:", error);
+				});
+
+				// Add close handler
+				res.on("close", () => {
+					sseTransport = null;
+					console.log("SSE connection closed");
+				});
+
+				sseTransport = new SSEServerTransport("/sse", res);
+
+				await server.connect(sseTransport);
+
+				console.log("SSE connection setup complete");
+			} else if (req.method === "POST") {
+				if (!sseTransport) {
+					res.writeHead(400);
+					res.end("No active SSE connection");
+					return;
+				}
+
+				await sseTransport.handlePostMessage(req, res);
+			}
+		} else {
+			res.writeHead(404);
+			res.end();
+		}
+	});
+
+	httpServer.on("error", (error) => {
+		console.error("Server error:", error);
+	});
+
+	httpServer.listen(3020, () => {
+		console.error(
+			"stability-ai MCP Server running on SSE at http://localhost:3020"
+		);
+	});
+}

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -14,19 +14,8 @@ export async function runSSEServer(server: Server) {
 	app.post("/messages", (req, res) => {
 		if (sseTransport) {
 			sseTransport.handlePostMessage(req, res);
-		} else {
-			res.status(400).send("No active SSE connection");
 		}
 	});
 
-	// Handle 404s for all other routes
-	app.use((req, res) => {
-		res.status(404).end();
-	});
-
-	app.listen(3020, () => {
-		console.error(
-			"stability-ai MCP Server running on SSE at http://localhost:3020"
-		);
-	});
+	app.listen(3020);
 }

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -6,16 +6,31 @@ export async function runSSEServer(server: Server) {
 	let sseTransport: SSEServerTransport | null = null;
 	const app = express();
 
-	app.get("/sse", (req, res) => {
+	app.get("/sse", async (req, res) => {
 		sseTransport = new SSEServerTransport("/messages", res);
-		server.connect(sseTransport);
+		await server.connect(sseTransport);
+
+		res.on("close", () => {
+			sseTransport = null;
+		});
 	});
 
-	app.post("/messages", (req, res) => {
+	app.post("/messages", async (req, res) => {
 		if (sseTransport) {
-			sseTransport.handlePostMessage(req, res);
+			await sseTransport.handlePostMessage(req, res);
+		} else {
+			res.status(400).send("No active SSE connection");
 		}
 	});
 
-	app.listen(3020);
+	// Handle 404s for all other routes
+	app.use((req, res) => {
+		res.status(404).end();
+	});
+
+	app.listen(3020, () => {
+		console.error(
+			"stability-ai MCP Server running on SSE at http://localhost:3020"
+		);
+	});
 }

--- a/src/sse.ts
+++ b/src/sse.ts
@@ -1,34 +1,30 @@
 import { SSEServerTransport } from "@modelcontextprotocol/sdk/server/sse.js";
-import http from "http";
+import express from "express";
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 
 export async function runSSEServer(server: Server) {
 	let sseTransport: SSEServerTransport | null = null;
+	const app = express();
 
-	const httpServer = http.createServer(async (req, res) => {
-		console.log(`${req.method} request to ${req.url}`);
+	app.get("/sse", (req, res) => {
+		sseTransport = new SSEServerTransport("/messages", res);
+		server.connect(sseTransport);
+	});
 
-		if (req.url?.startsWith("/sse") && req.method === "GET") {
-			sseTransport = new SSEServerTransport("/messages", res);
-			await server.connect(sseTransport);
-
-			res.on("close", () => {
-				sseTransport = null;
-			});
-		} else if (req.url?.startsWith("/messages") && req.method === "POST") {
-			if (sseTransport) {
-				await sseTransport.handlePostMessage(req, res);
-			} else {
-				res.writeHead(400);
-				res.end("No active SSE connection");
-			}
+	app.post("/messages", (req, res) => {
+		if (sseTransport) {
+			sseTransport.handlePostMessage(req, res);
 		} else {
-			res.writeHead(404);
-			res.end();
+			res.status(400).send("No active SSE connection");
 		}
 	});
 
-	httpServer.listen(3020, () => {
+	// Handle 404s for all other routes
+	app.use((req, res) => {
+		res.status(404).end();
+	});
+
+	app.listen(3020, () => {
 		console.error(
 			"stability-ai MCP Server running on SSE at http://localhost:3020"
 		);

--- a/src/stdio.ts
+++ b/src/stdio.ts
@@ -1,0 +1,8 @@
+import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+export async function runStdioServer(server: Server) {
+	const transport = new StdioServerTransport();
+	await server.connect(transport);
+	console.error("stability-ai MCP Server running on stdio");
+}

--- a/src/tools/controlSketch.ts
+++ b/src/tools/controlSketch.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
 import open from "open";
 import { z } from "zod";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const ControlSketchArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -49,16 +50,18 @@ export const controlSketchToolDefinition = {
 	},
 };
 
-export async function controlSketch(args: ControlSketchArgs) {
+export async function controlSketch(
+	args: ControlSketchArgs,
+	context: ResourceContext
+) {
 	const validatedArgs = ControlSketchArgsSchema.parse(args);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	try {

--- a/src/tools/controlSketch.ts
+++ b/src/tools/controlSketch.ts
@@ -79,8 +79,10 @@ export async function controlSketch(
 			imageAsBase64
 		);
 
-		const file_location = resource.uri.replace("file://", "");
-		open(file_location);
+		if (resource.uri.includes("file://")) {
+			const file_location = resource.uri.replace("file://", "");
+			open(file_location);
+		}
 
 		return {
 			content: [

--- a/src/tools/controlStructure.ts
+++ b/src/tools/controlStructure.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const ControlStructureArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -48,14 +49,16 @@ export const controlStructureToolDefinition = {
 	},
 };
 
-export const controlStructure = async (args: ControlStructureArgs) => {
+export const controlStructure = async (
+	args: ControlStructureArgs,
+	context: ResourceContext
+) => {
 	const validatedArgs = ControlStructureArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/controlStructure.ts
+++ b/src/tools/controlStructure.ts
@@ -73,8 +73,11 @@ export const controlStructure = async (
 	const filename = `${validatedArgs.outputImageFileName}.png`;
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/controlStyle.ts
+++ b/src/tools/controlStyle.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const ControlStyleArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -65,14 +66,16 @@ export const controlStyleToolDefinition = {
 	},
 };
 
-export const controlStyle = async (args: ControlStyleArgs) => {
+export const controlStyle = async (
+	args: ControlStyleArgs,
+	context: ResourceContext
+) => {
 	const validatedArgs = ControlStyleArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/controlStyle.ts
+++ b/src/tools/controlStyle.ts
@@ -91,8 +91,11 @@ export const controlStyle = async (
 	const filename = `${validatedArgs.outputImageFileName}.png`;
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/generateImage.ts
+++ b/src/tools/generateImage.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
 import open from "open";
 import { z } from "zod";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 // Constants for shared values
 const ASPECT_RATIOS = [
@@ -96,7 +97,10 @@ export const generateImageToolDefinition = {
 	},
 } as const;
 
-export const generateImage = async (args: GenerateImageArgs) => {
+export const generateImage = async (
+	args: GenerateImageArgs,
+	context: ResourceContext
+) => {
 	const {
 		prompt,
 		aspectRatio,
@@ -115,10 +119,12 @@ export const generateImage = async (args: GenerateImageArgs) => {
 	const imageAsBase64 = response.base64Image;
 	const filename = `${outputImageFileName}.png`;
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
+	const resourceClient = getResourceClient();
+	const resource = await resourceClient.createResource(
+		filename,
+		imageAsBase64,
+		context
 	);
-	const resource = await resourceClient.createResource(filename, imageAsBase64);
 
 	const file_location = resource.uri.replace("file://", "");
 	open(file_location);

--- a/src/tools/generateImage.ts
+++ b/src/tools/generateImage.ts
@@ -126,8 +126,10 @@ export const generateImage = async (
 		context
 	);
 
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/listResources.ts
+++ b/src/tools/listResources.ts
@@ -1,4 +1,5 @@
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 export const listResourcesToolDefinition = {
 	name: "stability-ai-0-list-resources",
@@ -12,11 +13,9 @@ export const listResourcesToolDefinition = {
 } as const;
 
 // List all available Resources via tool. Useful for clients that have limited capability for referencing resources within tool calls.
-export const listResources = async () => {
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
-	const resources = await resourceClient.listResources();
+export const listResources = async (context: ResourceContext) => {
+	const resourceClient = getResourceClient();
+	const resources = await resourceClient.listResources(context);
 
 	return {
 		content: resources.map((r) => ({

--- a/src/tools/outpaint.ts
+++ b/src/tools/outpaint.ts
@@ -91,8 +91,10 @@ export async function outpaint(args: OutpaintArgs, context: ResourceContext) {
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
 
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/outpaint.ts
+++ b/src/tools/outpaint.ts
@@ -1,7 +1,8 @@
 import { z } from "zod";
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
 import open from "open";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const OutpaintArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -60,14 +61,13 @@ export const outpaintToolDefinition = {
 	},
 };
 
-export async function outpaint(args: OutpaintArgs) {
+export async function outpaint(args: OutpaintArgs, context: ResourceContext) {
 	const validatedArgs = OutpaintArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	// Ensure at least one direction is specified

--- a/src/tools/removeBackground.ts
+++ b/src/tools/removeBackground.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const RemoveBackgroundArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -30,11 +31,12 @@ export const removeBackgroundToolDefinition = {
 	},
 };
 
-export const removeBackground = async (args: RemoveBackgroundArgs) => {
+export const removeBackground = async (
+	args: RemoveBackgroundArgs,
+	context: ResourceContext
+) => {
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY);
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 
 	const imageFilePath = await resourceClient.resourceToFile(args.imageFileUri);
 	const response = await client.removeBackground(imageFilePath);
@@ -42,7 +44,11 @@ export const removeBackground = async (args: RemoveBackgroundArgs) => {
 	const imageAsBase64 = response.base64Image;
 	const filename = `${args.outputImageFileName}.png`;
 
-	const resource = await resourceClient.createResource(filename, imageAsBase64);
+	const resource = await resourceClient.createResource(
+		filename,
+		imageAsBase64,
+		context
+	);
 	const file_location = resource.uri.replace("file://", "");
 	open(file_location);
 

--- a/src/tools/removeBackground.ts
+++ b/src/tools/removeBackground.ts
@@ -49,8 +49,11 @@ export const removeBackground = async (
 		imageAsBase64,
 		context
 	);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/replaceBackgroundAndRelight.ts
+++ b/src/tools/replaceBackgroundAndRelight.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const ReplaceBackgroundAndRelightArgsSchema = z
 	.object({
@@ -93,15 +94,15 @@ export const replaceBackgroundAndRelightToolDefinition = {
 };
 
 export const replaceBackgroundAndRelight = async (
-	args: ReplaceBackgroundAndRelightArgs
+	args: ReplaceBackgroundAndRelightArgs,
+	context: ResourceContext
 ) => {
 	const validatedArgs = ReplaceBackgroundAndRelightArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/replaceBackgroundAndRelight.ts
+++ b/src/tools/replaceBackgroundAndRelight.ts
@@ -139,8 +139,11 @@ export const replaceBackgroundAndRelight = async (
 	const filename = `${validatedArgs.outputImageFileName}.png`;
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/searchAndRecolor.ts
+++ b/src/tools/searchAndRecolor.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const SearchAndRecolorArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -41,14 +42,16 @@ export const searchAndRecolorToolDefinition = {
 	},
 };
 
-export const searchAndRecolor = async (args: SearchAndRecolorArgs) => {
+export const searchAndRecolor = async (
+	args: SearchAndRecolorArgs,
+	context: ResourceContext
+) => {
 	const validatedArgs = SearchAndRecolorArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/searchAndRecolor.ts
+++ b/src/tools/searchAndRecolor.ts
@@ -65,8 +65,11 @@ export const searchAndRecolor = async (
 	const filename = `${validatedArgs.outputImageFileName}.png`;
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/searchAndReplace.ts
+++ b/src/tools/searchAndReplace.ts
@@ -61,8 +61,11 @@ export async function searchAndReplace(
 	const filename = `${validatedArgs.outputImageFileName}.png`;
 
 	const resource = await resourceClient.createResource(filename, imageAsBase64);
-	const file_location = resource.uri.replace("file://", "");
-	open(file_location);
+
+	if (resource.uri.includes("file://")) {
+		const file_location = resource.uri.replace("file://", "");
+		open(file_location);
+	}
 
 	return {
 		content: [

--- a/src/tools/searchAndReplace.ts
+++ b/src/tools/searchAndReplace.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
 import open from "open";
 import { z } from "zod";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const SearchAndReplaceArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -40,14 +41,16 @@ export const searchAndReplaceToolDefinition = {
 	},
 };
 
-export async function searchAndReplace(args: SearchAndReplaceArgs) {
+export async function searchAndReplace(
+	args: SearchAndReplaceArgs,
+	context: ResourceContext
+) {
 	const validatedArgs = SearchAndReplaceArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/upscaleCreative.ts
+++ b/src/tools/upscaleCreative.ts
@@ -77,8 +77,11 @@ export async function upscaleCreative(
 			filename,
 			imageAsBase64
 		);
-		const file_location = resource.uri.replace("file://", "");
-		open(file_location);
+
+		if (resource.uri.includes("file://")) {
+			const file_location = resource.uri.replace("file://", "");
+			open(file_location);
+		}
 
 		return {
 			content: [

--- a/src/tools/upscaleCreative.ts
+++ b/src/tools/upscaleCreative.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
 import open from "open";
 import { z } from "zod";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const UpscaleCreativeArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -48,14 +49,16 @@ export const upscaleCreativeToolDefinition = {
 	},
 };
 
-export async function upscaleCreative(args: UpscaleCreativeArgs) {
+export async function upscaleCreative(
+	args: UpscaleCreativeArgs,
+	context: ResourceContext
+) {
 	const validatedArgs = UpscaleCreativeArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/upscaleFast.ts
+++ b/src/tools/upscaleFast.ts
@@ -1,7 +1,8 @@
 import { StabilityAiApiClient } from "../stabilityAi/stabilityAiApiClient.js";
 import open from "open";
 import { z } from "zod";
-import { ResourceClient } from "../resources/resourceClient.js";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
 
 const UpscaleFastArgsSchema = z.object({
 	imageFileUri: z.string(),
@@ -30,14 +31,16 @@ export const upscaleFastToolDefinition = {
 	},
 };
 
-export async function upscaleFast(args: UpscaleFastArgs) {
+export async function upscaleFast(
+	args: UpscaleFastArgs,
+	context: ResourceContext
+) {
 	const validatedArgs = UpscaleFastArgsSchema.parse(args);
 
-	const resourceClient = new ResourceClient(
-		process.env.IMAGE_STORAGE_DIRECTORY
-	);
+	const resourceClient = getResourceClient();
 	const imageFilePath = await resourceClient.resourceToFile(
-		validatedArgs.imageFileUri
+		validatedArgs.imageFileUri,
+		context
 	);
 
 	const client = new StabilityAiApiClient(process.env.STABILITY_AI_API_KEY!);

--- a/src/tools/upscaleFast.ts
+++ b/src/tools/upscaleFast.ts
@@ -55,8 +55,11 @@ export async function upscaleFast(
 			filename,
 			imageAsBase64
 		);
-		const file_location = resource.uri.replace("file://", "");
-		open(file_location);
+
+		if (resource.uri.includes("file://")) {
+			const file_location = resource.uri.replace("file://", "");
+			open(file_location);
+		}
 
 		return {
 			content: [


### PR DESCRIPTION
Stdio mode continues to work with no changes (perhaps a little breaking change in that I added a dependency, and now I think `-y` is a necessary argument in the `npx` command that was previously sans-`-y` in the README).

SSE description in README:

## SSE Mode

This server has the option to run in SSE mode by starting it with the following command:

```bash
npx mcp-server-stability-ai -y --sse
```

This mode is useful if you intend to deploy this server for third party usage over HTTP.

You will need to set the `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_BUCKET_NAME`, and `GCS_PRIVATE_KEY` environment variables, because the server will store image files in Google Cloud Storage instead of its local filesystem.

Note that the scheme for multitenancy is very naive and insecure: it uses the requestor's IP address to segment the GCS prefixes used to the store the images, and makes all images publicly accessible in order to communicate them back to the MCP client. So in theory, if someone knows your IP address and then name(s) of files you generated, they could access your images by guessing the URL.