### PR TITLE
Add support for SD3.5-specific endpoint

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,16 @@
 # Changelog
 
+## 0.2.0
+
+- Add support for Stable Diffusion 3.5 models with the `stability-ai-generate-image-sd35` tool
+- Support advanced configuration options for SD3.5:
+  - Model selection (SD3.5 Large, Medium, Turbo)
+  - CFG scale parameter
+  - Various output formats and aspect ratios
+  - Negative prompts
+  - Style presets
+  - Random seed control
+
 ## 0.1.0
 
 - Remove base64 encoding approach to saving images to filesystem (wasn't properly functional)

--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This server is built and tested on macOS with Claude Desktop. It should work wit
 | Tool Name                        | Description                                                                                        | Estimated Stability API Cost |
 | -------------------------------- | -------------------------------------------------------------------------------------------------- | ---------------------------- |
 | `generate-image`                 | Generate a high quality image of anything based on a provided prompt & other optional parameters.  | $0.03                        |
+| `generate-image-sd35`            | Generate an image using Stable Diffusion 3.5 models with advanced configuration options.           | $0.04-$0.07                  |
 | `remove-background`              | Remove the background from an image.                                                               | $0.02                        |
 | `outpaint`                       | Extend an image in any direction while maintaining visual consistency.                             | $0.04                        |
 | `search-and-replace`             | Replace objects or elements in an image by describing what to replace and what to replace it with. | $0.04                        |
@@ -84,6 +85,12 @@ This server is built and tested on macOS with Claude Desktop. It should work wit
 1. `Generate an image of a cat`
 2. `Generate a photorealistic image of a cat in a cyberpunk city, neon lights reflecting off its fur, 16:9 aspect ratio`
 3. `Generate a detailed digital art piece of a cat wearing a space suit floating through a colorful nebula, style preset: digital-art, aspect ratio: 21:9`
+
+## Generate an image with SD3.5
+
+1. `Generate an image of a woman with cybernetic wolf ears using the SD3.5 model, with the "neon-punk" style preset`
+2. `Generate an image of a futuristic city using the SD3.5 Large Turbo model, with aspect ratio 16:9`
+3. `Generate an image of an astronaut on mars using the SD3.5 Large model, with cfg scale 7.5, "analog-film" style preset, and seed 42`
 
 ## Remove background
 
@@ -215,6 +222,9 @@ You will need to set the `GCS_PROJECT_ID`, `GCS_CLIENT_EMAIL`, `GCS_BUCKET_NAME`
 Note that the scheme for multitenancy is very naive and insecure: it uses the requestor's IP address to segment the GCS prefixes used to the store the images, and makes all images publicly accessible in order to communicate them back to the MCP client. So in theory, if someone knows your IP address and then name(s) of files you generated, they could access your images by guessing the URL.
 
 ## Roadmap
+
+Recently completed:
+- ✅ Added support for the latest Stable Diffusion 3.5 models
 
 These are coming soon; but PR's are welcome! See [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "mcp-server-stability-ai",
-  "version": "0.1.0",
-  "lockfileVersion": 3,
+  "version": "0.2.0",
+  "lockfileVersion": 4,
   "requires": true,
   "packages": {
     "": {
       "name": "mcp-server-stability-ai",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
         "@google-cloud/storage": "^7.15.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "zod": "^3.24.1"
   },
   "name": "mcp-server-stability-ai",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "MCP [Model Context Protocol](https://modelcontextprotocol.io/) Server integrating MCP Clients with [Stability AI](https://stability.ai/) image manipulation functionalities: generate, edit, upscale, and more.",
   "main": "index.js",
   "keywords": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,6 +15,9 @@ import {
 	generateImage,
 	GenerateImageArgs,
 	generateImageToolDefinition,
+	generateImageSD35,
+	GenerateImageSD35Args,
+	generateImageSD35ToolDefinition,
 	removeBackground,
 	RemoveBackgroundArgs,
 	removeBackgroundToolDefinition,
@@ -166,6 +169,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
 		switch (name) {
 			case generateImageToolDefinition.name:
 				return generateImage(args as GenerateImageArgs, context);
+			case generateImageSD35ToolDefinition.name:
+				return generateImageSD35(args as GenerateImageSD35Args, context);
 			case removeBackgroundToolDefinition.name:
 				return removeBackground(args as RemoveBackgroundArgs, context);
 			case outpaintToolDefinition.name:
@@ -211,6 +216,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
 	return {
 		tools: [
 			generateImageToolDefinition,
+			generateImageSD35ToolDefinition,
 			removeBackgroundToolDefinition,
 			outpaintToolDefinition,
 			searchAndReplaceToolDefinition,

--- a/src/stabilityAi/sd35Client.ts
+++ b/src/stabilityAi/sd35Client.ts
@@ -1,0 +1,138 @@
+import axios, { AxiosInstance } from "axios";
+import FormData from "form-data";
+import fs from "fs";
+
+interface GenerateImageOptions {
+  prompt: string;
+  mode?: "text-to-image" | "image-to-image";
+  image?: string; // Path to image file for image-to-image
+  strength?: number; // For image-to-image mode, range 0-1
+  aspect_ratio?: "16:9" | "1:1" | "21:9" | "2:3" | "3:2" | "4:5" | "5:4" | "9:16" | "9:21";
+  model?: "sd3.5-large" | "sd3.5-large-turbo" | "sd3.5-medium" | "sd3-large" | "sd3-large-turbo" | "sd3-medium";
+  seed?: number; // Range 0-4294967294
+  output_format?: "jpeg" | "png";
+  style_preset?: "3d-model" | "analog-film" | "anime" | "cinematic" | "comic-book" | "digital-art" | "enhance" | "fantasy-art" | "isometric" | "line-art" | "low-poly" | "modeling-compound" | "neon-punk" | "origami" | "photographic" | "pixel-art" | "tile-texture";
+  negative_prompt?: string; // Max 10000 characters
+  cfg_scale?: number; // Range 1-10
+}
+
+export class SD35Client {
+  private readonly apiKey: string;
+  private readonly baseUrl = "https://api.stability.ai";
+  private readonly axiosClient: AxiosInstance;
+
+  constructor(apiKey: string) {
+    this.apiKey = apiKey;
+    this.axiosClient = axios.create({
+      baseURL: this.baseUrl,
+      timeout: 60000,
+      maxBodyLength: Infinity,
+      maxContentLength: Infinity,
+      headers: {
+        Authorization: `Bearer ${this.apiKey}`,
+        Accept: "image/*",
+      },
+    });
+  }
+
+  async generateImage(options: GenerateImageOptions): Promise<Buffer> {
+    const formData = new FormData();
+    
+    // Required parameter
+    if (!options.prompt || options.prompt.length === 0) {
+      throw new Error("Prompt is required and cannot be empty");
+    }
+    if (options.prompt.length > 10000) {
+      throw new Error("Prompt cannot exceed 10000 characters");
+    }
+    formData.append("prompt", options.prompt);
+    
+    // Set the mode (default to text-to-image)
+    const mode = options.mode || "text-to-image";
+    formData.append("mode", mode);
+    
+    // Add specific parameters based on mode
+    if (mode === "image-to-image") {
+      if (!options.image) {
+        throw new Error("Image path is required for image-to-image mode");
+      }
+      formData.append("image", fs.createReadStream(options.image));
+      
+      // Strength is required for image-to-image
+      if (options.strength === undefined) {
+        throw new Error("Strength parameter is required for image-to-image mode");
+      }
+      if (options.strength < 0 || options.strength > 1) {
+        throw new Error("Strength must be between 0 and 1");
+      }
+      formData.append("strength", options.strength.toString());
+    } else {
+      // aspect_ratio is only valid for text-to-image
+      if (options.aspect_ratio) {
+        formData.append("aspect_ratio", options.aspect_ratio);
+      }
+    }
+    
+    // Optional parameters
+    if (options.model) {
+      formData.append("model", options.model);
+    }
+    
+    if (options.seed !== undefined) {
+      if (options.seed < 0 || options.seed > 4294967294) {
+        throw new Error("Seed must be between 0 and 4294967294");
+      }
+      formData.append("seed", options.seed.toString());
+    }
+    
+    if (options.output_format) {
+      formData.append("output_format", options.output_format);
+    }
+    
+    if (options.style_preset) {
+      formData.append("style_preset", options.style_preset);
+    }
+    
+    if (options.negative_prompt) {
+      if (options.negative_prompt.length > 10000) {
+        throw new Error("Negative prompt cannot exceed 10000 characters");
+      }
+      formData.append("negative_prompt", options.negative_prompt);
+    }
+    
+    if (options.cfg_scale !== undefined) {
+      if (options.cfg_scale < 1 || options.cfg_scale > 10) {
+        throw new Error("CFG scale must be between 1 and 10");
+      }
+      formData.append("cfg_scale", options.cfg_scale.toString());
+    }
+    
+    try {
+      const response = await this.axiosClient.post(
+        "/v2beta/stable-image/generate/sd3",
+        formData,
+        {
+          headers: {
+            ...formData.getHeaders(),
+          },
+          responseType: "arraybuffer",
+        }
+      );
+      
+      return response.data;
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response) {
+        const data = error.response.data;
+        if (error.response.status === 400) {
+          let errorMessage = "Invalid parameters";
+          if (data.errors && Array.isArray(data.errors)) {
+            errorMessage += `: ${data.errors.join(", ")}`;
+          }
+          throw new Error(errorMessage);
+        }
+        throw new Error(`API error (${error.response.status}): ${JSON.stringify(data)}`);
+      }
+      throw error;
+    }
+  }
+}

--- a/src/tools/generateImageSD35.ts
+++ b/src/tools/generateImageSD35.ts
@@ -1,0 +1,186 @@
+import { z } from "zod";
+import { ResourceContext } from "../resources/resourceClient.js";
+import { getResourceClient } from "../resources/resourceClientFactory.js";
+import { SD35Client } from "../stabilityAi/sd35Client.js";
+import open from "open";
+
+// Constants for shared values
+const ASPECT_RATIOS = [
+  "16:9",
+  "1:1", 
+  "21:9",
+  "2:3",
+  "3:2",
+  "4:5",
+  "5:4",
+  "9:16",
+  "9:21"
+] as const;
+
+const STYLE_PRESETS = [
+  "3d-model",
+  "analog-film",
+  "anime",
+  "cinematic",
+  "comic-book",
+  "digital-art",
+  "enhance",
+  "fantasy-art",
+  "isometric",
+  "line-art",
+  "low-poly",
+  "modeling-compound",
+  "neon-punk",
+  "origami",
+  "photographic",
+  "pixel-art",
+  "tile-texture"
+] as const;
+
+const MODELS = [
+  "sd3.5-large",
+  "sd3.5-large-turbo",
+  "sd3.5-medium",
+  "sd3-large",
+  "sd3-large-turbo",
+  "sd3-medium"
+] as const;
+
+// Zod schema
+const GenerateImageSD35ArgsSchema = z.object({
+  prompt: z.string().min(1, "Prompt cannot be empty").max(10000),
+  aspectRatio: z.enum(ASPECT_RATIOS).optional().default("1:1"),
+  negativePrompt: z.string().max(10000).optional(),
+  stylePreset: z.enum(STYLE_PRESETS).optional(),
+  cfgScale: z.number().min(1).max(10).optional(),
+  seed: z.number().min(0).max(4294967294).optional(),
+  model: z.enum(MODELS).optional().default("sd3.5-large"),
+  outputFormat: z.enum(["jpeg", "png"]).optional().default("png"),
+  outputImageFileName: z.string()
+});
+
+export type GenerateImageSD35Args = z.infer<typeof GenerateImageSD35ArgsSchema>;
+
+// Tool definition
+export const generateImageSD35ToolDefinition = {
+  name: "stability-ai-generate-image-sd35",
+  description: "Generate an image using Stable Diffusion 3.5 models with advanced configuration options.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      prompt: {
+        type: "string",
+        description: "What you wish to see in the output image. A strong, descriptive prompt that clearly defines elements, colors, and subjects will lead to better results.",
+        minLength: 1,
+        maxLength: 10000
+      },
+      aspectRatio: {
+        type: "string",
+        enum: ASPECT_RATIOS,
+        description: "Controls the aspect ratio of the generated image.",
+        default: "1:1"
+      },
+      negativePrompt: {
+        type: "string",
+        description: "Keywords of what you do not wish to see in the output image. This helps avoid unwanted elements. Maximum 10000 characters.",
+        maxLength: 10000
+      },
+      stylePreset: {
+        type: "string",
+        enum: STYLE_PRESETS,
+        description: "Guides the image model towards a particular style."
+      },
+      cfgScale: {
+        type: "number",
+        minimum: 1,
+        maximum: 10,
+        description: "How strictly the diffusion process adheres to the prompt text. Values range from 1-10, with higher values keeping your image closer to your prompt."
+      },
+      seed: {
+        type: "number",
+        minimum: 0,
+        maximum: 4294967294,
+        description: "A specific value that guides the 'randomness' of the generation. (Omit or use 0 for random seed)"
+      },
+      model: {
+        type: "string",
+        enum: MODELS,
+        description: "The model to use for generation: SD3.5 Large (8B params, high quality), Medium (2.5B params, balanced), or Turbo (faster) variants. SD3.5 costs range from 3.5-6.5 credits per generation.",
+        default: "sd3.5-large"
+      },
+      outputFormat: {
+        type: "string",
+        enum: ["jpeg", "png"],
+        description: "The format of the output image.",
+        default: "png"
+      },
+      outputImageFileName: {
+        type: "string",
+        description: "The desired name of the output image file, no file extension."
+      }
+    },
+    required: ["prompt", "outputImageFileName"]
+  }
+} as const;
+
+// Implementation
+export const generateImageSD35 = async (
+  args: GenerateImageSD35Args,
+  context: ResourceContext
+) => {
+  const {
+    prompt,
+    aspectRatio,
+    negativePrompt,
+    stylePreset,
+    cfgScale,
+    seed,
+    model,
+    outputFormat,
+    outputImageFileName
+  } = GenerateImageSD35ArgsSchema.parse(args);
+
+  const client = new SD35Client(process.env.STABILITY_AI_API_KEY);
+  
+  // Convert to SD35Client format
+  const imageBuffer = await client.generateImage({
+    prompt,
+    aspect_ratio: aspectRatio,
+    negative_prompt: negativePrompt,
+    style_preset: stylePreset,
+    cfg_scale: cfgScale,
+    seed,
+    model,
+    output_format: outputFormat,
+    mode: "text-to-image"
+  });
+
+  // Convert buffer to base64
+  const imageAsBase64 = imageBuffer.toString('base64');
+  const filename = `${outputImageFileName}.${outputFormat}`;
+
+  const resourceClient = getResourceClient();
+  const resource = await resourceClient.createResource(
+    filename,
+    imageAsBase64,
+    context
+  );
+
+  if (resource.uri.includes("file://")) {
+    const file_location = resource.uri.replace("file://", "");
+    open(file_location);
+  }
+
+  return {
+    content: [
+      {
+        type: "text",
+        text: `Processed \`${prompt}\` with ${model} to create the following image:`,
+      },
+      {
+        type: "resource",
+        resource: resource,
+      },
+    ],
+  };
+};

--- a/src/tools/index.ts
+++ b/src/tools/index.ts
@@ -1,4 +1,5 @@
 export * from "./generateImage.js";
+export * from "./generateImageSD35.js";
 export * from "./removeBackground.js";
 export * from "./outpaint.js";
 export * from "./searchAndReplace.js";


### PR DESCRIPTION
Adds `stability-ai-generate-image-sd35` which uses the SD3.5-specific endpoint, with selection of model and more tweakable variables like CFG scale.

https://platform.stability.ai/docs/api-reference#tag/Generate/paths/~1v2beta~1stable-image~1generate~1sd3/post