### PR TITLE
Generate Image: support full set of options

### DIFF
--- a/src/stabilityAi/stabilityAiApiClient.ts
+++ b/src/stabilityAi/stabilityAiApiClient.ts
@@ -144,6 +144,9 @@ export class StabilityAiApiClient {
 		const payload = {
 			prompt,
 			output_format: "png",
+			aspect_ratio: options?.aspectRatio,
+			negative_prompt: options?.negativePrompt,
+			style_preset: options?.stylePreset,
 			...options,
 		};
 


### PR DESCRIPTION
Given `/generate/core` options:
```
...
  aspectRatio?: _;
  negativePrompt?: string;
  stylePreset?: _;
...
```
Expected `/generate/core` options:
```
...
  aspect_ratio?: _;
  negative_prompt?: string;
  style_preset?: _;
...
```